### PR TITLE
Updated platformio.ini to build reliably

### DIFF
--- a/Firmware/Marlin-bugfix-2.0.x/platformio.ini
+++ b/Firmware/Marlin-bugfix-2.0.x/platformio.ini
@@ -21,7 +21,7 @@ build_dir   = .pioenvs
 lib_dir     = .piolib
 libdeps_dir = .piolibdeps
 boards_dir  = buildroot/share/PlatformIO/boards
-env_default = LPC1769
+default_envs = LPC1769
 
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
@@ -31,7 +31,7 @@ build_flags = -fmax-errors=5
 lib_deps =
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   LiquidCrystal@1.3.4
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.2,<0.5.3
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
   https://github.com/ameyer/Arduino-L6470/archive/dev.zip
@@ -165,7 +165,7 @@ monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.2,<0.5.3
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
 
 [env:LPC1769]
@@ -184,7 +184,7 @@ monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.2,<0.5.3
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
 
 #


### PR DESCRIPTION
Fixed platformio.ini to compile and build reliably again.

* Renamed env_default to default_envs to suppress platformio compatibility warning
* Changed TMCStepper Version from >1.0.0 to 0.5.2 to prevent the build failing